### PR TITLE
Fix spacing issue on index.

### DIFF
--- a/lib/app/views/index.erb
+++ b/lib/app/views/index.erb
@@ -30,6 +30,7 @@
       <p>
         Please select a version of FHIR to test and enter a FHIR endpoint to get started.
       </p>
+    </div>
 
     <% end%>
 


### PR DESCRIPTION
Minor spacing issue of footer fix due to missed `</div>` on index page.

<img width="1105" alt="Screen Shot 2019-06-29 at 3 48 10 PM" src="https://user-images.githubusercontent.com/412901/60388941-e5033a80-9a86-11e9-990e-93c22f92a019.png">
